### PR TITLE
[Feature] Added new filter, which hides components with given name.

### DIFF
--- a/packages/bratus-app/src/App.js
+++ b/packages/bratus-app/src/App.js
@@ -32,6 +32,9 @@ const App = () => {
   // Input value that filers components by the number of 'timesUsed'
   const [componentNumberFilter, setComponentNumberFilter] = useState(null);
 
+  // Input value that filers components by the number of 'timesUsed'
+  const [componentNameFilter, setComponentNameFilter] = useState(null);
+
   // Inform the application about the tree direction at all times.
   const [treeLayoutDirection, setTreeLayoutDirection] = useState(undefined);
 
@@ -77,6 +80,7 @@ const App = () => {
         setIsSubtreeMode={setIsSubtreeMode}
         setComponentLabelFilter={setComponentLabelFilter}
         setComponentNumberFilter={setComponentNumberFilter}
+        setComponentNameFilter={setComponentNameFilter}
         setNodeDetail={setNodeDetail}
         isVerticalTreeLayoutAsDefault={isVerticalTreeLayoutAsDefault}
         setVerticalTreeLayoutAsDefault={setVerticalTreeLayoutAsDefault}
@@ -85,6 +89,7 @@ const App = () => {
           <ComponentTree
             componentLabelFilter={componentLabelFilter}
             componentNumberFilter={componentNumberFilter}
+            componentNameFilter={componentNameFilter}
             treeLayoutDirection={treeLayoutDirection}
             isSubtreeMode={isSubtreeMode}
             setIsSubtreeMode={setIsSubtreeMode}

--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
@@ -87,7 +87,8 @@ const ComponentTree = ({
   );
 
   // Fit tree on the screen
-  const onLoadTree = (reactFlowInstance) => reactFlowInstance.fitView();
+  const onLoadTree = (reactFlowInstance) =>
+    reactFlowInstance.fitView({ duration: 500 });
 
   // Highlight nodes on hover
   const highlightComponent = (node) => {

--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
@@ -11,11 +11,12 @@ export const GraphDirectionContext = React.createContext(null);
 
 const ComponentTree = ({
   nodesAndEdges,
+  isSubtreeMode,
   componentLabelFilter,
   componentNumberFilter,
+  componentNameFilter,
   treeLayoutDirection,
   setTreeLayoutDirection,
-  isSubtreeMode,
 }) => {
   const [layoutedNodesAndEdges, setLayoutedNodesAndEdges] =
     useState(nodesAndEdges);
@@ -40,6 +41,10 @@ const ComponentTree = ({
     );
     setTimeout(() => reactFlowInstance.fitView({ duration: 500 }), 0);
   }, [componentNumberFilter]);
+
+  useEffect(() => {
+    console.log('useEffect from name', componentNameFilter);
+  }, [componentNameFilter]);
 
   const [filteredNodesAndEdges, setFilteredNodesAndEdges] = useState([]);
 
@@ -173,6 +178,7 @@ ComponentTree.propTypes = {
   treeLayoutDirection: PropTypes.any,
   componentLabelFilter: PropTypes.any,
   componentNumberFilter: PropTypes.any,
+  componentNameFilter: PropTypes.any,
   setTreeLayoutDirection: PropTypes.any,
   isSubtreeMode: PropTypes.any,
 };

--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
@@ -21,7 +21,7 @@ const ComponentTree = ({
   const [layoutedNodesAndEdges, setLayoutedNodesAndEdges] =
     useState(nodesAndEdges);
 
-  // Will run when the component is mounted.
+  // Filter: Will run when the filter switch is toggled on/off.
   useEffect(() => {
     setFilteredNodesAndEdges(
       filterLeaveOnlyComponentsByName(layoutedNodesAndEdges, rootComponentLabel)
@@ -29,7 +29,7 @@ const ComponentTree = ({
     setTimeout(() => reactFlowInstance.fitView({ duration: 500 }), 0);
   }, [isSubtreeMode]);
 
-  // Will run every time the incoming componentLabelFilter changes.
+  // Filter: Hides all components but the one specified by the chosen name and its subtree.
   useEffect(() => {
     setFilteredNodesAndEdges(
       filterLeaveOnlyComponentsByName(
@@ -49,9 +49,8 @@ const ComponentTree = ({
     setTimeout(() => reactFlowInstance.fitView({ duration: 500 }), 0);
   }, [componentNumberFilter]);
 
-  //
+  // Filter: Hides the component specified by the given name and its subtree.
   useEffect(() => {
-    console.log('useEffect from name', componentNameFilter);
     setFilteredNodesAndEdges(
       filterRemoveComponentsByName(filteredNodesAndEdges, componentNameFilter)
     );

--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
@@ -27,7 +27,7 @@ const ComponentTree = ({
       filterLeaveOnlyComponentsByName(layoutedNodesAndEdges, rootComponentLabel)
     );
     setTimeout(() => reactFlowInstance.fitView({ duration: 500 }), 0);
-  }, []);
+  }, [isSubtreeMode]);
 
   // Will run every time the incoming componentLabelFilter changes.
   useEffect(() => {

--- a/packages/bratus-app/src/components/DefaultLayoutPage/DefaultLayout.jsx
+++ b/packages/bratus-app/src/components/DefaultLayoutPage/DefaultLayout.jsx
@@ -26,6 +26,7 @@ const DefaultLayout = ({
   setNodeDetail,
   setComponentLabelFilter,
   setComponentNumberFilter,
+  setComponentNameFilter,
   isVerticalTreeLayoutAsDefault,
   setVerticalTreeLayoutAsDefault,
 }) => {
@@ -82,6 +83,7 @@ const DefaultLayout = ({
           isNavCollapsed={isNavCollapsed}
           setComponentLabelFilter={setComponentLabelFilter}
           setComponentNumberFilter={setComponentNumberFilter}
+          setComponentNameFilter={setComponentNameFilter}
         />
 
         <NavigationTriggerButton
@@ -158,6 +160,7 @@ DefaultLayout.propTypes = {
   setNodeDetail: PropTypes.func,
   setComponentLabelFilter: PropTypes.func,
   setComponentNumberFilter: PropTypes.func,
+  setComponentNameFilter: PropTypes.func,
   isSubtreeMode: PropTypes.bool,
   setIsSubtreeMode: PropTypes.func,
 };

--- a/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/NavigationPanel.jsx
@@ -31,6 +31,7 @@ const NavigationPanel = ({
   setIsHelpVisible,
   setComponentLabelFilter,
   setComponentNumberFilter,
+  setComponentNameFilter,
   isSubtreeMode,
   setIsSubtreeMode,
 }) => {
@@ -60,6 +61,7 @@ const NavigationPanel = ({
             <NavSearchComponent
               setComponentLabelFilter={setComponentLabelFilter}
               setComponentNumberFilter={setComponentNumberFilter}
+              setComponentNameFilter={setComponentNameFilter}
               isSubtreeMode={isSubtreeMode}
               setIsSubtreeMode={setIsSubtreeMode}
             />
@@ -111,6 +113,7 @@ NavigationPanel.propTypes = {
   setIsHelpVisible: PropTypes.any,
   setComponentLabelFilter: PropTypes.func,
   setComponentNumberFilter: PropTypes.func,
+  setComponentNameFilter: PropTypes.func,
   isSubtreeMode: PropTypes.bool,
   setIsSubtreeMode: PropTypes.func,
 };

--- a/packages/bratus-app/src/components/NavigationPanel/private/SubMenuSections/NavSearchComponent.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/private/SubMenuSections/NavSearchComponent.jsx
@@ -16,10 +16,11 @@ import { Input, Switch } from 'antd';
 import { FilterOutlined } from '@ant-design/icons';
 
 const NavSearchComponent = ({
-  setComponentLabelFilter,
-  setComponentNumberFilter,
   isSubtreeMode,
   setIsSubtreeMode,
+  setComponentLabelFilter,
+  setComponentNumberFilter,
+  setComponentNameFilter,
 }) => {
   const { setCenter, fitView } = useZoomPanHelper();
 
@@ -55,14 +56,14 @@ const NavSearchComponent = ({
   const [numberForFilter, setNumberForFilter] = useState(undefined);
 
   // State for the component name for filtering.
-  const [componentNameForFilter, setComponentNameForFilter] = useState('');
+  const [nameForFilter, setNameForFilter] = useState('');
 
   function handleNumberInputChange(e) {
     setNumberForFilter(e.target.value);
   }
 
   function handleNameInputChange(e) {
-    setComponentNameForFilter(e.target.value);
+    setNameForFilter(e.target.value);
   }
 
   // Bring selected node in the center of the screen.
@@ -181,8 +182,7 @@ const NavSearchComponent = ({
           </SearchNodeExplanationText>
 
           <TimesUsedInputGroup compact>
-            <Input type="number" onChange={handleInputChange} />
-            <Input onChange={handleNumberInputChange} />
+            <Input type="number" onChange={handleNumberInputChange} />
             <TimesUsedButton
               onClick={() => {
                 numberForFilter && setComponentNumberFilter(numberForFilter);
@@ -202,7 +202,7 @@ const NavSearchComponent = ({
             <Input onChange={handleNameInputChange} />
             <TimesUsedButton
               onClick={() => {
-                setComponentNameForFilter(componentNameForFilter);
+                setComponentNameFilter(nameForFilter);
               }}
               type="primary"
             >
@@ -227,11 +227,12 @@ const NavSearchComponent = ({
 };
 
 NavSearchComponent.propTypes = {
-  setComponentLabelFilter: PropTypes.func,
-  setComponentNumberFilter: PropTypes.func,
   nodesAndEdges: PropTypes.any,
   isSubtreeMode: PropTypes.bool,
   setIsSubtreeMode: PropTypes.func,
+  setComponentLabelFilter: PropTypes.func,
+  setComponentNumberFilter: PropTypes.func,
+  setComponentNameFilter: PropTypes.func,
 };
 
 export default NavSearchComponent;

--- a/packages/bratus-app/src/components/NavigationPanel/private/SubMenuSections/NavSearchComponent.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/private/SubMenuSections/NavSearchComponent.jsx
@@ -54,8 +54,15 @@ const NavSearchComponent = ({
   // State for the number input.
   const [numberForFilter, setNumberForFilter] = useState(undefined);
 
-  function handleInputChange(e) {
+  // State for the component name for filtering.
+  const [componentNameForFilter, setComponentNameForFilter] = useState('');
+
+  function handleNumberInputChange(e) {
     setNumberForFilter(e.target.value);
+  }
+
+  function handleNameInputChange(e) {
+    setComponentNameForFilter(e.target.value);
   }
 
   // Bring selected node in the center of the screen.
@@ -175,9 +182,27 @@ const NavSearchComponent = ({
 
           <TimesUsedInputGroup compact>
             <Input type="number" onChange={handleInputChange} />
+            <Input onChange={handleNumberInputChange} />
             <TimesUsedButton
               onClick={() => {
                 numberForFilter && setComponentNumberFilter(numberForFilter);
+              }}
+              type="primary"
+            >
+              Apply Filter
+            </TimesUsedButton>
+          </TimesUsedInputGroup>
+
+          {/* Input field for the 'filter component by name' */}
+          <SearchNodeExplanationText>
+            Hide components by the specified name:
+          </SearchNodeExplanationText>
+
+          <TimesUsedInputGroup compact>
+            <Input onChange={handleNameInputChange} />
+            <TimesUsedButton
+              onClick={() => {
+                setComponentNameForFilter(componentNameForFilter);
               }}
               type="primary"
             >

--- a/packages/bratus-app/src/components/NavigationPanel/private/SubMenuSections/NavSearchComponent.jsx
+++ b/packages/bratus-app/src/components/NavigationPanel/private/SubMenuSections/NavSearchComponent.jsx
@@ -174,7 +174,7 @@ const NavSearchComponent = ({
           </SearchNodeExplanationText>
 
           <TimesUsedInputGroup compact>
-            <Input onChange={handleInputChange} />
+            <Input type="number" onChange={handleInputChange} />
             <TimesUsedButton
               onClick={() => {
                 numberForFilter && setComponentNumberFilter(numberForFilter);


### PR DESCRIPTION
If the user wants to hide a specified component, maybe in order to clean up the tree view, there is now an option to do this.

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/71826552/169820728-524735fa-3930-4095-8db3-a53002c53259.png">

P.

closes #83 