### PR TITLE
Interaction with the canvas changes based on if the user uses a trackpad or a mouse.

### DIFF
--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
@@ -151,22 +151,29 @@ const ComponentTree = ({
     }
   };
 
-  // Spots if the user uses a trackpad or a mousepad
+  // Holds the state for the user interaction
   const [isTrackPad, setIsTrackPad] = useState(false);
 
-  // TO DO: Write you beautiful comment here, YO!
+  /**
+   * @description this function spots if the user uses a mousepad or a
+   * trackpad, and the pane interaction changes accordingly. The interaction
+   * is done like a Figma canvas. We need this, as, otherwise, it moves the
+   * canvas on mouse scroll.
+   * @param {*} e mouse or trackpad event
+   */
   function detectTrackPad(e) {
     var isTouchPad = e.wheelDeltaY
       ? e.wheelDeltaY === -3 * e.deltaY
       : e.deltaMode === 0;
 
-    console.log(isTouchPad ? 'isTouchPad' : 'isMouse');
     setIsTrackPad(isTouchPad);
   }
-  const myCanvas = document.querySelector('.react-flow__pane');
-  if (myCanvas) {
-    myCanvas.addEventListener('mousewheel', detectTrackPad, false);
-    myCanvas.addEventListener('DOMMouseScroll', detectTrackPad, false);
+
+  const reactFlowPane = document.querySelector('.react-flow__pane');
+
+  if (reactFlowPane) {
+    reactFlowPane.addEventListener('mousewheel', detectTrackPad, false);
+    reactFlowPane.addEventListener('DOMMouseScroll', detectTrackPad, false);
   }
 
   // Reset highlightComponents (Empty array).

--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
@@ -1,6 +1,6 @@
 import ReactFlow, { isNode, useZoomPanHelper } from 'react-flow-renderer';
 import PropTypes from 'prop-types';
-import React, { useContext, useState, useEffect, useCallback } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import HighlightedComponentsContext from '../../contexts/HighlightedComponentsContext';
 import ComponentNode from '../ComponentNode/ComponentNode';
 import LayoutButtons from './private/LayoutButtons';
@@ -154,21 +154,20 @@ const ComponentTree = ({
   // Spots if the user uses a trackpad or a mousepad
   const [isTrackPad, setIsTrackPad] = useState(false);
 
-  const detectTrackPad = useCallback((e) => {
-    var isTrackpad = false;
-    if (e.wheelDeltaY) {
-      if (e.wheelDeltaY === e.deltaY * -3) {
-        isTrackpad = true;
-      }
-    } else if (e.deltaMode === 0) {
-      isTrackpad = true;
-    }
-    console.log(isTrackpad ? 'Trackpad detected' : 'Mousewheel detected');
-    setIsTrackPad(isTrackpad);
-  }, []);
+  // TO DO: Write you beautiful comment here, YO!
+  function detectTrackPad(e) {
+    var isTouchPad = e.wheelDeltaY
+      ? e.wheelDeltaY === -3 * e.deltaY
+      : e.deltaMode === 0;
 
-  document.addEventListener('mousewheel', detectTrackPad, false);
-  document.addEventListener('DOMMouseScroll', detectTrackPad, false);
+    console.log(isTouchPad ? 'isTouchPad' : 'isMouse');
+    setIsTrackPad(isTouchPad);
+  }
+  const myCanvas = document.querySelector('.react-flow__pane');
+  if (myCanvas) {
+    myCanvas.addEventListener('mousewheel', detectTrackPad, false);
+    myCanvas.addEventListener('DOMMouseScroll', detectTrackPad, false);
+  }
 
   // Reset highlightComponents (Empty array).
   const resetHighlight = () => setHighlightedComponents([]);

--- a/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
+++ b/packages/bratus-app/src/components/ComponentTree/ComponentTree.jsx
@@ -1,6 +1,6 @@
 import ReactFlow, { isNode, useZoomPanHelper } from 'react-flow-renderer';
 import PropTypes from 'prop-types';
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext, useState, useEffect, useCallback } from 'react';
 import HighlightedComponentsContext from '../../contexts/HighlightedComponentsContext';
 import ComponentNode from '../ComponentNode/ComponentNode';
 import LayoutButtons from './private/LayoutButtons';
@@ -151,6 +151,25 @@ const ComponentTree = ({
     }
   };
 
+  // Spots if the user uses a trackpad or a mousepad
+  const [isTrackPad, setIsTrackPad] = useState(false);
+
+  const detectTrackPad = useCallback((e) => {
+    var isTrackpad = false;
+    if (e.wheelDeltaY) {
+      if (e.wheelDeltaY === e.deltaY * -3) {
+        isTrackpad = true;
+      }
+    } else if (e.deltaMode === 0) {
+      isTrackpad = true;
+    }
+    console.log(isTrackpad ? 'Trackpad detected' : 'Mousewheel detected');
+    setIsTrackPad(isTrackpad);
+  }, []);
+
+  document.addEventListener('mousewheel', detectTrackPad, false);
+  document.addEventListener('DOMMouseScroll', detectTrackPad, false);
+
   // Reset highlightComponents (Empty array).
   const resetHighlight = () => setHighlightedComponents([]);
 
@@ -186,7 +205,7 @@ const ComponentTree = ({
             onNodeMouseEnter={(_e, node) => highlightComponent(node, false)}
             onNodeMouseLeave={(_e, node) => removeHighlight(node)}
             onPaneClick={resetHighlight}
-            panOnScroll={true}
+            panOnScroll={isTrackPad}
             minZoom={0}
             defaultZoom={0}
           >


### PR DESCRIPTION
Closes #82
Closes #79 

@mircealungu You have pointed out that scrolling with the mouse moved the pane instead of zooming in.

Now, the program knows if the user is using a trackpad or a mouse, and interaction with react-flow is done accordingly, like in software like Figma. You can still move the canvas with the 2 fingers but also zoom in with the wheel if you use a mouse.